### PR TITLE
bug: Fix widget return values when using ModelChoiceField

### DIFF
--- a/autocomplete/widgets.py
+++ b/autocomplete/widgets.py
@@ -5,6 +5,7 @@ from django.forms import Widget
 
 from .autocomplete import HTMXAutoComplete
 
+
 class Autocomplete(Widget):
     """
     Django forms compatible autocomplete widget
@@ -48,7 +49,7 @@ class Autocomplete(Widget):
 
         if use_ac is None:
             config = {
-                "name": opts.get("route_name", name),
+                "name": name,
                 "disabled": attrs.get("disabled", False) if attrs else False,
                 "required": attrs.get("required", False) if attrs else False,
                 "indicator": opts.get("indicator", None),
@@ -87,7 +88,17 @@ class Autocomplete(Widget):
             getter = data.getlist
         except AttributeError:
             getter = data.get
-        return getter(name)
+        buf = getter(name)
+
+        if not self.a_c.multiselect:
+            try:
+                return buf[0]
+            except IndexError:
+                return -1
+            except TypeError:
+                pass
+
+        return buf
 
     def value_omitted_from_data(self, data, files, name):
         # An unselected <select multiple> doesn't appear in POST data, so it's

--- a/tests/app/ac_test/forms.py
+++ b/tests/app/ac_test/forms.py
@@ -45,6 +45,9 @@ class SingleFormModel(forms.ModelForm):
 
         model = Team
         fields = ["name", "members"]
+        field_classes = {
+            "members": forms.ModelChoiceField
+        }
         widgets = {
             "members": widgets.Autocomplete(
                 name="members", options=dict(model=Person, minimum_search_length=0)

--- a/tests/app/ac_test/views.py
+++ b/tests/app/ac_test/views.py
@@ -11,7 +11,6 @@ from .forms import (
 
 
 def index(request):
-    print(request.POST)
     template = loader.get_template("index.html")
     single_form_get_item = SingleFormGetItem({"name": "Team Pickle", "company": [2]})
     single_form_model = SingleFormModel({"name": "Team Pickles", "members": [1]})


### PR DESCRIPTION
There were 2 issues, 
  1) Single select widget was return an array to the field
  2) The component name was mistakenly overridden by the using route_name

fixes #33