### PR TITLE
fix: chip should have hx-target this

### DIFF
--- a/autocomplete/templates/autocomplete/chip.html
+++ b/autocomplete/templates/autocomplete/chip.html
@@ -11,6 +11,7 @@ This template renders a selected item or chip.
         hx-vals='{"name": "{{ name|escapejs }}", "component_id": "{{ component_id|escapejs }}", "remove": true, "item": "{{ item.value|escapejs }}"}'
         hx-include="#{{ component_id }}"
         hx-swap="delete"
+        hx-target="this"
         tabindex="-1"
         href="#"
     >


### PR DESCRIPTION
Probably should have been covered in  https://github.com/PHACDataHub/django-htmx-autocomplete/commit/c018677925033c35abd4bb4c0e99699bce96d75a