### PR TITLE
fix: xss: unescaped component_prefix

### DIFF
--- a/autocomplete/templatetags/autocomplete.py
+++ b/autocomplete/templatetags/autocomplete.py
@@ -209,7 +209,7 @@ def base_configurable_hx_vals(context):
 
     props = {
         "field_name": escape(field_name),
-        "component_prefix": component_prefix,
+        "component_prefix": escape(component_prefix),
     }
 
     if required:


### PR DESCRIPTION
can be tested locally with this URL:

127.0.0.1:8000/ac/autocomplete/CustomPersonAutocomplete/items?team_lead=201&field_name=team_lead&component_prefix=ABCD%27%3e%3cscript%3ealert(%27XSS-Injected%27)%3c%2fscript%3eABCD&placeholder=Select%20team%20lead!&search=Stephen%200
