### PR TITLE
fix: A11y fixes

### DIFF
--- a/autocomplete/static/autocomplete/css/autocomplete.css
+++ b/autocomplete/static/autocomplete/css/autocomplete.css
@@ -269,9 +269,10 @@
     outline: 2px solid #000;
 }
 
-.phac_aspc_form_autocomplete .results .item.selected {
-    display: list-item;
-    color: #ccc;
+.phac_aspc_form_autocomplete .results .item.selected::after {
+    content: "✓";
+    position: absolute;
+    right: 0.75rem;
 }
 
 .phac_aspc_form_autocomplete li.input.ac-active {

--- a/autocomplete/templates/autocomplete/item_list.html
+++ b/autocomplete/templates/autocomplete/item_list.html
@@ -19,7 +19,12 @@
         </span>
     {% elif not items %}
         <span class="item">
-            {% use_string "no_results" custom_strings %}
+            {% use_string "no_results" custom_strings as no_result_str %}
+            {% if no_result_str %}
+                {{ no_result_str }}
+            {% else %}
+                {% use_string "available_results" custom_strings %}
+            {% endif %}
         </span>
     {% endif %}
 
@@ -34,10 +39,20 @@
 </div>
 
 <div hx-swap-oob="innerHTML" id="{{ component_id }}__info">
-    {% if items|length != total_results %}
+    {% if query_too_short %}
+        {% use_string "type_at_least_n_characters" custom_strings as str_template %}
+        {% substitute_string str_template n=minimum_search_length %}
+    {% elif items|length != total_results %}
         {% use_string "more_results" custom_strings as more_results_template %}
         {% substitute_string more_results_template page_size=items|length total=total_results %}
+    {% elif items|length %}
+        {% use_string "available_results" custom_strings %}
     {% else %}
-    {% use_string "available_results" custom_strings %}
+        {% use_string "no_results" custom_strings as no_result_str %}
+        {% if no_result_str %}
+            {{ no_result_str }}
+        {% else %}
+            {% use_string "available_results" custom_strings %}
+        {% endif %}
     {% endif %}
 </div>  


### PR DESCRIPTION
1. use checkmark rather than poor contrast highlight <img width="315" height="203" alt="Screenshot 2025-08-20 at 14 31 54" src="https://github.com/user-attachments/assets/f98f1263-cb53-48ba-a601-fa9885c8bf3e" />
2. Announce the same things in the aria-live region as are shown in the text itself (e.g. no results, type at least N characters)