### PR TITLE
feat: Always show selected items in selection list

### DIFF
--- a/autocomplete/static/autocomplete/css/autocomplete.css
+++ b/autocomplete/static/autocomplete/css/autocomplete.css
@@ -275,6 +275,13 @@
     right: 0.75rem;
 }
 
+.phac_aspc_form_autocomplete .results .item .phac_aspc_form_autocomplete__item__spaceholder {
+    /* makes room for the checkmark */
+    display:inline-block;
+    width: 0.75rem;
+    content: " ";
+}
+
 .phac_aspc_form_autocomplete li.input.ac-active {
     min-width: 50px !important;
 }

--- a/autocomplete/templates/autocomplete/item.html
+++ b/autocomplete/templates/autocomplete/item.html
@@ -18,6 +18,7 @@
    {% if swap_oob %} hx-swap-oob="outerHTML:#{{ component_id }}__item__{{ item.key|make_id }}" {% else %} hx-target="this" {% endif %}
 >
     {{ item.label|search_highlight:search }}
+    <span class="phac_aspc_form_autocomplete__item__spaceholder" aria-hidden="true"></span>
 </a>
 
 {% if toggle is not None %}

--- a/sample_app/urls.py
+++ b/sample_app/urls.py
@@ -46,6 +46,11 @@ urlpatterns = [
         views.example_w_html,
         name="example_w_custom_html",
     ),
+    path(
+        "teams/<int:team_id>/example_w_id_search/",
+        views.example_w_id_search,
+        name="example_w_id_search",
+    ),
     path("ac/", autocomplete_urls),
     path("app/__debug__/", include("debug_toolbar.urls")),
 ]

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -81,7 +81,8 @@ def test_items_response_multi(client):
 
         @classmethod
         def get_items_from_keys(cls, keys, context):
-            return Person.objects.filter(id__in=keys)
+            qs = Person.objects.filter(id__in=keys)
+            return [{"key": person.id, "label": person.name} for person in qs]
 
     register(PersonAC2)
 


### PR DESCRIPTION
In single-select mode it can be difficult to un-select a choice, especially if the label isn't reverse-searchable. 

So now, both single and multi-select will always show the selected option(s) in the list, and those selected items will be shown at the top.

Selected items don't count towards pagination, so this can't lead to an edge case where someone adds enough items and can't see any new ones due to the limit. 

<img width="508" height="155" alt="Screenshot 2025-08-20 at 16 34 02" src="https://github.com/user-attachments/assets/15267f1d-9eeb-418d-bb25-9029541fadef" />
