### PR TITLE
feat: allow changing autocomplete attribute to prevent autofill

### DIFF
--- a/autocomplete/core.py
+++ b/autocomplete/core.py
@@ -12,6 +12,8 @@ _ac_registry = {}
 
 AC_CLASS_CONFIGURABLE_VALUES = {
     "disabled",
+    # autocomplete_attr is the <input> attribute, used by browser to suggest values
+    "autocomplete_attr",
     "no_result_text",
     "narrow_search_text",
     "minimum_search_length",

--- a/autocomplete/templates/autocomplete/textinput.html
+++ b/autocomplete/templates/autocomplete/textinput.html
@@ -6,7 +6,7 @@
     id="{{ component_id }}__textinput"
     type="text"
 
-    autocomplete="fake_{{ component_id| make_id }}_value"
+    autocomplete="{{ autocomplete_attr_value }}"
     autocapitalize="none"
 
     role="combobox"

--- a/autocomplete/views.py
+++ b/autocomplete/views.py
@@ -46,6 +46,15 @@ class AutocompleteBaseView(View):
 
         return None
 
+    def get_autocomplete_attr(self):
+        """Return the value for the autocomplete attribute."""
+        autocomplete_value = self.get_configurable_value("autocomplete_attr")
+
+        if autocomplete_value is not None:
+            return autocomplete_value
+
+        return "off"
+
     def get_template_context(self):
         # many things will come from the request
         # others will be picked up from the AC class
@@ -62,6 +71,7 @@ class AutocompleteBaseView(View):
             "multiselect": bool(self.get_configurable_value("multiselect")),
             "component_prefix": self.get_configurable_value("component_prefix"),
             "disabled": bool(self.get_configurable_value("disabled")),
+            "autocomplete_attr_value": self.get_autocomplete_attr(),
         }
 
 

--- a/autocomplete/widgets.py
+++ b/autocomplete/widgets.py
@@ -67,6 +67,12 @@ class AutocompleteWidget(Widget):
 
         return None
 
+    def get_autocomplete_attr(self):
+        if self.get_configurable_value("autocomplete_attr"):
+            return self.get_configurable_value("autocomplete_attr")
+
+        return "off"
+
     @property
     def is_multi(self):
         return self.get_configurable_value("multiselect")
@@ -102,5 +108,7 @@ class AutocompleteWidget(Widget):
         context["selected_items"] = selected_options
         context["component_prefix"] = self.get_configurable_value("component_prefix")
         context["component_id"] = self.get_component_id(name)
+
+        context["autocomplete_attr_value"] = self.get_autocomplete_attr()
 
         return context

--- a/sample_app/urls.py
+++ b/sample_app/urls.py
@@ -51,6 +51,11 @@ urlpatterns = [
         views.example_w_id_search,
         name="example_w_id_search",
     ),
+    path(
+        "teams/<int:team_id>/example_w_custom_autocomplete_attr/",
+        views.example_w_custom_autocomplete_attr,
+        name="example_w_custom_autocomplete_attr",
+    ),
     path("ac/", autocomplete_urls),
     path("app/__debug__/", include("debug_toolbar.urls")),
 ]

--- a/sample_app/views.py
+++ b/sample_app/views.py
@@ -325,3 +325,37 @@ def example_w_id_search(request, team_id=None):
         return HttpResponseRedirect(request.path)
 
     return render(request, "edit_team.html", {"form": form})
+
+
+@register
+class AutocompleteWithCustomAttr(ModelAutocomplete):
+    model = Person
+    autocomplete_attr = "email"
+    search_attrs = ["name"]
+
+
+def example_w_custom_autocomplete_attr(request, team_id=None):
+
+    class TeamFormWithCustomAutocompleteAttr(forms.ModelForm):
+        class Meta:
+            model = Team
+            fields = ["team_lead", "members"]
+            widgets = {
+                "team_lead": AutocompleteWidget(
+                    ac_class=AutocompleteWithCustomAttr,
+                ),
+                "members": AutocompleteWidget(
+                    ac_class=AutocompleteWithCustomAttr,
+                    options={"multiselect": True},
+                ),
+            }
+
+    team = Team.objects.get(id=team_id)
+
+    form = TeamFormWithCustomAutocompleteAttr(instance=team, data=request.POST or None)
+
+    if request.POST and form.is_valid():
+        form.save()
+        return HttpResponseRedirect(request.path)
+
+    return render(request, "edit_team.html", {"form": form})

--- a/tests/test_widget_render.py
+++ b/tests/test_widget_render.py
@@ -443,3 +443,46 @@ def test_widget_with_lazy_string_placeholder():
 
     hx_vals = input.attrs["hx-vals"]
     assert '"placeholder": "lazy placeholder"' in hx_vals
+
+
+def test_base_autocomplete_attr_value():
+    class MyForm(forms.ModelForm):
+        class Meta:
+            model = Team
+            fields = ["team_lead"]
+
+            widgets = {
+                "team_lead": AutocompleteWidget(
+                    ac_class=PersonAC4,
+                )
+            }
+
+    form = MyForm()
+    rendered = render_template(single_form_template, {"form": form})
+    soup = soup_from_str(rendered)
+    input = soup.select_one("ul li input[type='text']")
+    assert input.attrs["autocomplete"] == "off"
+
+
+def test_custom_autocomplete_attr_value():
+
+    @register
+    class PersonAC4WithAutocompleteAttr(PersonAC4):
+        autocomplete_attr = "email"
+
+    class MyFormWithCustomAttr(forms.ModelForm):
+        class Meta:
+            model = Team
+            fields = ["team_lead"]
+
+            widgets = {
+                "team_lead": AutocompleteWidget(
+                    ac_class=PersonAC4WithAutocompleteAttr,
+                )
+            }
+
+    form = MyFormWithCustomAttr()
+    rendered = render_template(single_form_template, {"form": form})
+    soup = soup_from_str(rendered)
+    input = soup.select_one("ul li input[type='text']")
+    assert input.attrs["autocomplete"] == "email"


### PR DESCRIPTION
We started out using autocomplete="off", which is widely ignored by browsers, then we switched to using a random string, e.g. `fake_234323ef23`, which mostly worked but would trigger WCAG issues. 

Now it defaults to `autocomplete="off"`, but is customize-able on the autocomplete class using the `autocomplete_attr` property. We should probably document this. 

People who already override the template shouldn't have to change anything 

Fixes #79