### PR TITLE
fix: add aria-required when require option is used

### DIFF
--- a/autocomplete/templates/autocomplete/textinput.html
+++ b/autocomplete/templates/autocomplete/textinput.html
@@ -44,8 +44,18 @@
     value="{% get_input_value selected_items %}"
     {% endif %}
 
+    {% comment %}
+        TODO: figure out why we check length here - does it break multiselect?
+        the required attribute drops after selection, which breaks a11y 
+        in the meantime, we use aria-required
+    {% endcomment %}
+    
     {% if required and selected_items|length == 0 %}
     required
+    {% endif %}
+
+    {% if required %}
+    aria-required="true"
     {% endif %}
 
     {% if disabled %}

--- a/tests/test_widget_render.py
+++ b/tests/test_widget_render.py
@@ -307,6 +307,7 @@ def test_custom_options():
 
     assert input.attrs["placeholder"] == "my placeholder"
     assert "required" in input.attrs
+    assert "aria-required" in input.attrs
     assert "disabled" in input.attrs
 
     hx_vals = input.attrs["hx-vals"]


### PR DESCRIPTION
Currently, the required attribute on the `<input role="combonox">` only shows up if the selection is empty. 

I don't fully remember why we remove the require attribute if there are items. I'm guessing because default form-validation will fail if the input is empty, and if you're using multi-select, then the input will be empty even when items are technically selection. 

The only reason I care about this right now is because accessibility assessors don't like the required attribute being dropped, because screen-readers won't mark it as required anymore. Using aria-required doesn't trigger form validation and likely wouldn't cause the same bugs as required, and it sufficiently informs screen-readers to note it as required.  