### PR TITLE
fix: render placeholder attr even when there are items

### DIFF
--- a/autocomplete/templates/autocomplete/textinput.html
+++ b/autocomplete/templates/autocomplete/textinput.html
@@ -36,7 +36,7 @@
     hx-swap-oob="outerHTML:#{{ component_id }}__textinput"
     {% endif %}
 
-    {% if placeholder and selected_items|length == 0 %}
+    {% if placeholder %}
     placeholder="{{ placeholder }}"
     {% endif %}
     

--- a/sample_app/urls.py
+++ b/sample_app/urls.py
@@ -52,6 +52,11 @@ urlpatterns = [
         name="example_w_id_search",
     ),
     path(
+        "teams/<int:team_id>/example_w_placeholder/",
+        views.example_w_placeholder,
+        name="example_w_placeholder",
+    ),
+    path(
         "teams/<int:team_id>/example_w_custom_autocomplete_attr/",
         views.example_w_custom_autocomplete_attr,
         name="example_w_custom_autocomplete_attr",

--- a/sample_app/views.py
+++ b/sample_app/views.py
@@ -359,3 +359,33 @@ def example_w_custom_autocomplete_attr(request, team_id=None):
         return HttpResponseRedirect(request.path)
 
     return render(request, "edit_team.html", {"form": form})
+
+
+def example_w_placeholder(request, team_id=None):
+    class TeamFormWithPlaceholder(forms.ModelForm):
+        class Meta:
+            model = Team
+            fields = ["team_lead", "members"]
+            widgets = {
+                "team_lead": AutocompleteWidget(
+                    ac_class=PersonAutocomplete,
+                    options={"placeholder": "Select team lead here"},
+                ),
+                "members": AutocompleteWidget(
+                    ac_class=PersonAutocomplete,
+                    options={
+                        "multiselect": True,
+                        "placeholder": "Select team members here",
+                    },
+                ),
+            }
+
+    team = Team.objects.get(id=team_id)
+
+    form = TeamFormWithPlaceholder(instance=team, data=request.POST or None)
+
+    if request.POST and form.is_valid():
+        form.save()
+        return HttpResponseRedirect(request.path)
+
+    return render(request, "edit_team.html", {"form": form})


### PR DESCRIPTION
This may be controversial, but aXe reports unlabeled form elements. Placeholders are an easy way out here. We previously only rendered them when there were not items, which means aXe would report an unlabeled input when there are items populated. 

So now we render it regardless of how many items are selected. 

For single selects, there is no drawback as it's invisible. For multi-selects, the placeholder shows. It's a bit weird, and may actually trigger different issues if it gets clipped and can't be fully read. 

<img width="2064" height="496" alt="Screenshot 2025-12-19 at 12 40 37" src="https://github.com/user-attachments/assets/0b9aa682-54e6-4d01-b175-39f86e65018b" />

When I have more time, I'll look into adding a new a11y-friendly labeling. I think aria-label is the obvious answer here, but the people who built this knew more about a11y than I do and didn't use it 🤔 
