### PR TITLE
feat: add support for custom input attributes

### DIFF
--- a/autocomplete/core.py
+++ b/autocomplete/core.py
@@ -14,6 +14,7 @@ AC_CLASS_CONFIGURABLE_VALUES = {
     "disabled",
     # autocomplete_attr is the <input> attribute, used by browser to suggest values
     "autocomplete_attr",
+    "input_attrs",
     "no_result_text",
     "narrow_search_text",
     "minimum_search_length",
@@ -52,6 +53,7 @@ class Autocomplete:
     minimum_search_length = 3
     max_results = 100
     component_prefix = ""
+    input_attrs = {}
 
     @classmethod
     def auth_check(cls, request):

--- a/autocomplete/static/autocomplete/js/autocomplete.js
+++ b/autocomplete/static/autocomplete/js/autocomplete.js
@@ -2,7 +2,7 @@
 function phac_aspc_autocomplete_trigger_change(container_id) {
     setTimeout(() => {
         const container = document.getElementById(container_id);
-        const el = container.querySelector('.textinput');
+        const el = container.querySelector('[data-autocomplete-input]');
         el.dispatchEvent(new Event('change', { bubbles: true }));
     }, 0)
 }
@@ -13,13 +13,13 @@ function phac_aspc_autocomplete_clear_focus(container, activate_ring) {
         el.classList.remove('hasFocus');
     }
 
-    const el = container.querySelector('.textinput');
+    const el = container.querySelector('[data-autocomplete-input]');
     el.removeAttribute('aria-activedescendant');
 
     if (activate_ring) {
         container.closest('.phac_aspc_form_autocomplete_focus_ring')
             .classList.add('active');
-        container.querySelector('.textinput').focus();
+        container.querySelector('[data-autocomplete-input]').focus();
     } else {
         container.closest('.phac_aspc_form_autocomplete_focus_ring')
             .classList.remove('active');
@@ -28,7 +28,7 @@ function phac_aspc_autocomplete_clear_focus(container, activate_ring) {
 //private DONE
 function phac_aspc_autocomplete_hide_results(container) {
     const results = container.querySelector('.results');
-    const el = container.querySelector('.textinput');
+    const el = container.querySelector('[data-autocomplete-input]');
     el.setAttribute('aria-expanded', false);
     results.classList.remove('show');
 }
@@ -90,7 +90,7 @@ function phac_aspc_autocomplete_blur_handler(event, name, sync = false, item = f
             live.innerHTML = '';
 
             // Change the min-width of the text input back to the (small) default
-            parent.querySelector('.textinput')
+            parent.querySelector('[data-autocomplete-input]')
                 .parentElement.classList.remove('ac-active');
 
             // Ensure no elements remain 'focused', and set focus to input
@@ -130,7 +130,7 @@ function phac_aspc_autocomplete_set_initial_value(container, reset = false) {
     // stores current value of text input in variable
     // to enable restoring this value if a new value is not selected
     const id = container.getAttribute('id');
-    const el = container.querySelector('.textinput');
+    const el = container.querySelector('[data-autocomplete-input]');
     if (reset) {
         phac_aspc_autocomplete_initial_value[id] = undefined;
         return;
@@ -151,7 +151,7 @@ function phac_aspc_autocomplete_click_handler(event) {
     const id = container.getAttribute('id');
     const results = container.querySelector('.results');
     const open = results && results.classList.contains('show');
-    const text_box = container.querySelector('.textinput');
+    const text_box = container.querySelector('[data-autocomplete-input]');
 
     phac_aspc_autocomplete_set_initial_value(container);
     phac_aspc_autocomplete_clear_focus(container, true);
@@ -242,7 +242,7 @@ function phac_aspc_autocomplete_keydown_handler(event) {
     }
     const switchFocus = (element, container) => {
         phac_aspc_autocomplete_clear_focus(container);
-        const el = container.querySelector('.textinput');
+        const el = container.querySelector('[data-autocomplete-input]');
         el.setAttribute('aria-activedescendant', element.getAttribute('id'));
         element.classList.add('hasFocus');
         element.scrollIntoView({ block: 'nearest' })
@@ -466,9 +466,30 @@ class PhacAutocomplete {
         // in case consumer code is listening
         setTimeout(() => {
             const container = document.getElementById(containerId);
-            const el = container.querySelector('.textinput');
+            const el = container.querySelector('[data-autocomplete-input]');
             el.dispatchEvent(new Event('change', { bubbles: true }));
         }, 0)
+    }
+
+    static syncInputAttrsWithin(element){
+        if(!element){
+            return;
+        }
+
+        const roots = [];
+        if(element.matches && element.matches('[data-autocomplete-root]')){
+            roots.push(element);
+        }
+        if(element.querySelectorAll){
+            roots.push(...element.querySelectorAll('[data-autocomplete-root]'));
+        }
+
+        for(const root of roots){
+            const instance = this.getInstanceForElement(root);
+            if(instance){
+                instance.applyInputAttrsFromTemplate();
+            }
+        }
     }
 
     static focusInputHandler(event){
@@ -947,6 +968,62 @@ class PhacAutocomplete {
         return this.getContainer().querySelectorAll(`#${this.getComponentId()}_ac_container li.chip`);
     }
 
+    getInputAttrsTemplate(){
+        return document.getElementById(`${this.getComponentId()}__input_attrs`);
+    }
+
+    applyInputAttrsFromTemplate(){
+        const template = this.getInputAttrsTemplate();
+        const input = this.getInput();
+
+        if(!template || !input){
+            return;
+        }
+
+        const raw = template.content
+            ? template.content.textContent && template.content.textContent.trim()
+            : template.textContent && template.textContent.trim();
+        if(!raw){
+            return;
+        }
+
+        let inputAttrs;
+        try {
+            inputAttrs = JSON.parse(raw);
+        } catch (error) {
+            console.warn('Unable to parse autocomplete input attrs', error);
+            return;
+        }
+
+        for(const [name, value] of Object.entries(inputAttrs)){
+            if(value === null || value === undefined || value === false){
+                continue;
+            }
+
+            if(name === 'class'){
+                const classNames = Array.isArray(value)
+                    ? value
+                    : String(value).split(/\s+/);
+                for(const className of classNames){
+                    if(className){
+                        input.classList.add(className);
+                    }
+                }
+                continue;
+            }
+
+            // TODO: why skip existing ones?
+            //if(input.hasAttribute(name)){
+            //    continue;
+            //}
+
+            const attrValue = Array.isArray(value) || (typeof value === 'object' && value !== null)
+                ? JSON.stringify(value)
+                : String(value);
+            input.setAttribute(name, attrValue);
+        }
+    }
+
     clear(){
         this.getInput().value = '';
         this.getInputWrapper().innerHTML = '';
@@ -1016,6 +1093,7 @@ function initializeGlobalAutocompleteListeners(){
             if(!isEnabledAcRoot(ac_root)){
                 return;
             }
+            // PhacAutocomplete.syncInputAttrsWithin(ac_root);
             const componentId = ac_root.getAttribute('data-autocomplete-componentId');
             const toggleurl = ac_root.getAttribute('data-autocomplete-toggleurl');
 
@@ -1044,6 +1122,7 @@ function initializeGlobalAutocompleteListeners(){
                     if(instance){
                         // instance.storeExistingValue();
                         instance.resetExistingValue();
+                        //instance.applyInputAttrsFromTemplate();
                     }
                     //phac_aspc_autocomplete_set_initial_value(document.querySelector(`#${componentId}__container`), true);
                     const input = instance.getInput()
@@ -1070,6 +1149,23 @@ function initializeGlobalAutocompleteListeners(){
             }
         }
     });
+
+    function syncAttributesIfInput(evt){
+        const element = evt.detail.elt;
+        if(element.hasAttribute("data-autocomplete-input") || element.querySelector("[data-autocomplete-input]")){
+            const instance = PhacAutocomplete.getInstanceForElement(element);
+            if(instance){
+                instance.applyInputAttrsFromTemplate();
+            }
+        }
+    }
+    document.body.addEventListener('htmx:afterSwap', syncAttributesIfInput);
+
+    setTimeout(() => {
+        //initial rendering doesn't include custom input attributes
+        //only json into <template>
+        PhacAutocomplete.syncInputAttrsWithin(document);
+    }, 0);
 
 }
 

--- a/autocomplete/templates/autocomplete/component.html
+++ b/autocomplete/templates/autocomplete/component.html
@@ -38,6 +38,9 @@ This is the main component template that creates the basic HTML structure.
     {% endif %}
 
     {% include "./ac_container.html" %}
+    {% if input_attrs_json %}
+    <template id="{{ component_id }}__input_attrs">{{ input_attrs_json }}</template>
+    {% endif %}
     <div
       class="results"
       role="listbox"

--- a/autocomplete/templates/autocomplete/textinput.html
+++ b/autocomplete/templates/autocomplete/textinput.html
@@ -2,6 +2,8 @@
 
 {% if not disabled or not multiselect %}
 <input
+    data-autocomplete-input
+    
     class="textinput"
     id="{{ component_id }}__textinput"
     type="text"

--- a/autocomplete/widgets.py
+++ b/autocomplete/widgets.py
@@ -2,6 +2,8 @@
 This file enables the component to be used like other Django widgets
 """
 
+import json
+
 from django.forms import Widget
 
 from .core import AC_CLASS_CONFIGURABLE_VALUES, Autocomplete
@@ -16,6 +18,7 @@ class AutocompleteWidget(Widget):
         "label",
         "component_prefix",
         # the below are also configurable from the AC class
+        "input_attrs",
         "placeholder",
     ]
 
@@ -59,6 +62,9 @@ class AutocompleteWidget(Widget):
         return prefix + field_name
 
     def get_configurable_value(self, key):
+        if key == "input_attrs":
+            return self.get_input_attrs()
+
         if key in self.config:
             return self.config.get(key)
 
@@ -72,6 +78,12 @@ class AutocompleteWidget(Widget):
             return self.get_configurable_value("autocomplete_attr")
 
         return "off"
+
+    def get_input_attrs(self):
+        class_input_attrs = getattr(self.ac_class, "input_attrs", {}) or {}
+        option_input_attrs = self.config.get("input_attrs", {}) or {}
+
+        return {**dict(class_input_attrs), **dict(option_input_attrs)}
 
     @property
     def is_multi(self):
@@ -107,6 +119,11 @@ class AutocompleteWidget(Widget):
 
         context["label"] = self.get_configurable_value("label")
         context["placeholder"] = self.get_configurable_value("placeholder")
+        input_attrs = self.get_input_attrs()
+        context["input_attrs"] = input_attrs
+        context["input_attrs_json"] = (
+            json.dumps(input_attrs, default=str) if input_attrs else None
+        )
         # context["values"] = list(self.a_c.item_values(self.a_c, selected_options))
         context["values"] = [x["key"] for x in selected_options]
         context["selected_items"] = selected_options

--- a/sample_app/urls.py
+++ b/sample_app/urls.py
@@ -50,6 +50,11 @@ urlpatterns = [
         name="example_w_custom_html",
     ),
     path(
+        "teams/<int:team_id>/example_w_input_attrs/",
+        views.example_w_input_attrs,
+        name="example_w_input_attrs",
+    ),
+    path(
         "teams/<int:team_id>/example_w_id_search/",
         views.example_w_id_search,
         name="example_w_id_search",

--- a/sample_app/views.py
+++ b/sample_app/views.py
@@ -242,12 +242,14 @@ class AutocompleteWithCustomHtmlLabels(ModelAutocomplete):
         # this is a custom label for the autocomplete
         # it will be used in the dropdown
         # and in the selected items
-        return mark_safe(f"""
+        return mark_safe(
+            f"""
             <div>
                 <div>{record.name}</div>
                 <div style='color: red;'>{record.name.upper()}</div>
             </div>
-            """)
+            """
+        )
 
     @classmethod
     def get_input_value(cls, key, label):
@@ -256,9 +258,11 @@ class AutocompleteWithCustomHtmlLabels(ModelAutocomplete):
     @classmethod
     def get_chip_label(cls, key, label):
         name = Person.objects.get(id=key).name
-        return mark_safe(f"""
+        return mark_safe(
+            f"""
             <span style='color: red;'>{name.upper()}</span>
-            """)
+            """
+        )
 
 
 class CustomTeamFormWithHtmlAC(forms.ModelForm):
@@ -340,6 +344,51 @@ class AutocompleteWithCustomAttr(ModelAutocomplete):
     model = Person
     autocomplete_attr = "email"
     search_attrs = ["name"]
+
+
+@register
+class AutocompleteWithInputAttrs(PersonAutocomplete):
+    input_attrs = {
+        "aria-label": "Team lead autocomplete",
+        "data-input-attrs": "sample-app",
+    }
+
+
+class TeamFormWithInputAttrs(forms.ModelForm):
+    class Meta:
+        model = Team
+        fields = ["team_lead", "members"]
+        widgets = {
+            "team_lead": AutocompleteWidget(
+                ac_class=AutocompleteWithInputAttrs,
+                options={
+                    "input_attrs": {
+                        "placeholder": "Select CUSTOM team member",
+                    },
+                },
+            ),
+            "members": AutocompleteWidget(
+                ac_class=PersonAutocomplete,
+                options={
+                    "multiselect": True,
+                    "input_attrs": {
+                        "placeholder": "Select CUSTOM team members",
+                    },
+                },
+            ),
+        }
+
+
+def example_w_input_attrs(request, team_id=None):
+    team = Team.objects.get(id=team_id)
+
+    form = TeamFormWithInputAttrs(instance=team, data=request.POST or None)
+
+    if request.POST and form.is_valid():
+        form.save()
+        return HttpResponseRedirect(request.path)
+
+    return render(request, "edit_team.html", {"form": form})
 
 
 def example_w_custom_autocomplete_attr(request, team_id=None):

--- a/tests/selenium/selenium_util.py
+++ b/tests/selenium/selenium_util.py
@@ -45,6 +45,21 @@ def wait_until_selector_gone(driver, selector):
     )
 
 
+def wait_until_attribute(driver, selector, attribute, expected, **options):
+    from selenium.webdriver.support.ui import WebDriverWait
+
+    kwargs = {
+        "timeout": 0.5,
+        "poll_frequency": 0.1,
+    }
+    if options:
+        kwargs.update(options)
+
+    WebDriverWait(driver, **kwargs).until(
+        lambda d: get_element(d, selector).get_attribute(attribute) == expected
+    )
+
+
 def wait_until_stale(driver, element):
     from selenium.webdriver.support import expected_conditions
     from selenium.webdriver.support.ui import WebDriverWait

--- a/tests/selenium/test_live_widget.py
+++ b/tests/selenium/test_live_widget.py
@@ -8,6 +8,7 @@ from .selenium_util import (
     click_button,
     get_element,
     get_elements,
+    wait_until_attribute,
     wait_until_selector,
     wait_until_selector_gone,
 )
@@ -26,9 +27,24 @@ def test_single_select_live_widget(live_server, driver):
     t1 = TeamFactory(team_lead=p2)
     t1.members.set([p2, p3])
 
-    url = reverse("edit_team", args=[t1.pk])
+    url = reverse("example_w_input_attrs", args=[t1.pk])
 
     driver.get(live_server.url + url)
+
+    wait_until_attribute(
+        driver,
+        "input#team_lead__textinput",
+        "aria-label",
+        "Team lead autocomplete",
+        timeout=2,
+    )
+    wait_until_attribute(
+        driver,
+        "input#team_lead__textinput",
+        "data-input-attrs",
+        "sample-app",
+        timeout=2,
+    )
 
     def get_info_txt():
         info = get_element(driver, "#team_lead__info")
@@ -78,7 +94,15 @@ def test_single_select_live_widget(live_server, driver):
     assert "selected" in get_info_txt()
 
     # now check that the selected option is in the input box
+    wait_until_attribute(
+        driver,
+        "input#team_lead__textinput",
+        "aria-label",
+        "Team lead autocomplete",
+        timeout=2,
+    )
     input = get_element(driver, "input#team_lead__textinput")
+    assert input.get_attribute("data-input-attrs") == "sample-app"
     assert input.get_attribute("value") == "Sample Leader"
 
     # and that the invisible input has the correct value
@@ -182,6 +206,13 @@ def test_multi_select_live_widget(live_server, driver):
     )  # p1
 
     wait_until_selector_gone(driver, "#members__items.show")
+    wait_until_attribute(
+        driver,
+        "input#members__textinput",
+        "value",
+        "",
+        timeout=2,
+    )
 
     # now check the input is cleared
     input = get_element(driver, "input#members__textinput")

--- a/tests/test_widget_render.py
+++ b/tests/test_widget_render.py
@@ -1,3 +1,5 @@
+import json
+
 from django import forms
 from django.template import Context, Template, loader
 from django.urls import reverse
@@ -492,3 +494,44 @@ def test_custom_autocomplete_attr_value():
     soup = soup_from_str(rendered)
     input = soup.select_one("ul li input[type='text']")
     assert input.attrs["autocomplete"] == "email"
+
+
+def test_input_attrs_template_merges_class_and_widget_options():
+    @register
+    class PersonAC4WithInputAttrs(PersonAC4):
+        input_attrs = {
+            "aria-label": "class label",
+            "data-from-class": "class",
+        }
+
+    class MyFormWithInputAttrs(forms.ModelForm):
+        class Meta:
+            model = Team
+            fields = ["team_lead"]
+
+            widgets = {
+                "team_lead": AutocompleteWidget(
+                    ac_class=PersonAC4WithInputAttrs,
+                    options={
+                        "input_attrs": {
+                            "aria-label": "option label",
+                            "data-from-option": "option",
+                        }
+                    },
+                )
+            }
+
+    form = MyFormWithInputAttrs()
+    rendered = render_template(single_form_template, {"form": form})
+    soup = soup_from_str(rendered)
+
+    template = soup.select_one("template#team_lead__input_attrs")
+    assert template
+    assert json.loads(template.text) == {
+        "aria-label": "option label",
+        "data-from-class": "class",
+        "data-from-option": "option",
+    }
+
+    input = soup.select_one("ul li input[type='text']")
+    assert "aria-label" not in input.attrs


### PR DESCRIPTION
Will keep this in a branch/rc-release until I confirm it helps solve our a11y testing

- [ ] add docs for `input_attrs`

Not super happy with this API. using the standard `Widget` `attrs` API would be nice but
- there may be other elements than the input whose attributes we may want to modify. I could see us adding more attributes like, `chip_attributes`, `selected_ul_attributes`, `selected_li_attributes`, etc. . After a certain point, though, we should just let people render things themselves, somehow. 
- It may also break existing behavior as consumers may be passing attributes now that are getting ignored

